### PR TITLE
This add the possibility to define minimum and maximum for Duration

### DIFF
--- a/serde_valid/src/error.rs
+++ b/serde_valid/src/error.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use itertools::Itertools;
 use serde_valid_literal::Literal;
 
@@ -129,6 +130,25 @@ macro_rules! struct_error_params {
     };
 }
 
+#[derive(Debug, Clone)]
+pub struct MinimumDurationError {
+    pub minimum: Duration,
+}
+
+impl MinimumDurationError {
+    pub fn new<N: Into<Duration>>(limit: N) -> Self {
+        Self {
+            minimum: limit.into(),
+        }
+    }
+}
+
+impl FormatDefault for MinimumDurationError {
+    #[inline]
+    fn format_default(&self) -> String {
+        format!("Duration must be >= {:9}s", self.minimum.as_secs_f64())
+    }
+}
 // Number
 struct_error_params!(
     #[derive(Debug, Clone)]

--- a/serde_valid/src/error.rs
+++ b/serde_valid/src/error.rs
@@ -149,6 +149,27 @@ impl FormatDefault for MinimumDurationError {
         format!("Duration must be >= {:9}s", self.minimum.as_secs_f64())
     }
 }
+
+
+#[derive(Debug, Clone)]
+pub struct MaximumDurationError {
+    pub maximum: Duration,
+}
+
+impl MaximumDurationError {
+    pub fn new<N: Into<Duration>>(limit: N) -> Self {
+        Self {
+            maximum: limit.into(),
+        }
+    }
+}
+
+impl FormatDefault for MaximumDurationError {
+    #[inline]
+    fn format_default(&self) -> String {
+        format!("Duration must be <= {:9}s", self.maximum.as_secs_f64())
+    }
+}
 // Number
 struct_error_params!(
     #[derive(Debug, Clone)]

--- a/serde_valid/src/features/flatten/into_flat.rs
+++ b/serde_valid/src/features/flatten/into_flat.rs
@@ -1,4 +1,5 @@
 use jsonschema::paths::{JSONPointer, PathChunk};
+use crate::validation::Error;
 
 use crate::validation::error::{
     ArrayErrors, FormatDefault, ItemErrorsMap, Message, ObjectErrors, PropertyErrorsMap,
@@ -56,6 +57,7 @@ impl IntoFlat for crate::validation::Error {
             crate::validation::Error::Fluent(inner) => {
                 FlatErrors::new(vec![FlatError::new(path.to_owned(), inner.id.to_string())])
             }
+            Error::MinimumDuration(inner) => inner.into_flat_at(path)
         }
     }
 }

--- a/serde_valid/src/features/flatten/into_flat.rs
+++ b/serde_valid/src/features/flatten/into_flat.rs
@@ -57,7 +57,8 @@ impl IntoFlat for crate::validation::Error {
             crate::validation::Error::Fluent(inner) => {
                 FlatErrors::new(vec![FlatError::new(path.to_owned(), inner.id.to_string())])
             }
-            Error::MinimumDuration(inner) => inner.into_flat_at(path)
+            Error::MinimumDuration(inner) => inner.into_flat_at(path),
+            Error::MaximumDuration(inner) => inner.into_flat_at(path)
         }
     }
 }

--- a/serde_valid/src/lib.rs
+++ b/serde_valid/src/lib.rs
@@ -61,6 +61,12 @@
 //! | Array   | `#[validate(min_items = 5)]`         | [`ValidateMinItems`]         | [minItems](https://json-schema.org/understanding-json-schema/reference/array#length)          |
 //! | Array   | `#[validate(unique_items)]`          | [`ValidateUniqueItems`]      | [uniqueItems](https://json-schema.org/understanding-json-schema/reference/array#uniqueItems)  |
 //! | Generic | `#[validate(enumerate(5, 10, 15))]`  | [`ValidateEnumerate`]        | [enum](https://json-schema.org/understanding-json-schema/reference/enum)                      |
+//! Serde Valid support for Rust type not in JSON Schema
+//! The crate [serde_with](https://docs.rs/serde_with/latest/serde_with/) will help you to use serde with some type like Duration
+//! | Type    | Serde Valid(validate derive)         | Serde Valid(validate trait)  | Rust types                                                                                   |
+//! | :-----: | :----------------------------------- | :--------------------------- | :-------------------------------------------------------------------------------------------- |
+//! | Duration| `#[validate(minimum_duration = "30ms")]`  | [`ValidateMinimumDuration`]  | [duration](https://doc.rust-lang.org/std/time/struct.Duration.html)          |
+//! | Duration| `#[validate(maximum_duration = "30ms")]`  | [`ValidateMaximumDuration`]  | [duration](https://doc.rust-lang.org/std/time/struct.Duration.html)           |
 //!
 //! ## Complete Constructor (Deserialization)
 //!

--- a/serde_valid/src/validation.rs
+++ b/serde_valid/src/validation.rs
@@ -315,7 +315,7 @@ macro_rules! impl_generic_composited_validation_1args {
 }
 
 pub(crate) use impl_generic_composited_validation_1args;
-use crate::error::MinimumDurationError;
+use crate::error::{MaximumDurationError, MinimumDurationError};
 
 // Number
 impl_composited_validation_1args!(
@@ -333,6 +333,12 @@ impl_composited_validation_1args!(
 impl_composited_validation_1args!(
     pub trait ValidateCompositedMinimumDuration<T> {
         fn validate_composited_duration(&self, minimum: T) -> Result<(), Composited<MinimumDurationError>>;
+    }
+);
+
+impl_composited_validation_1args!(
+    pub trait ValidateCompositedMaximumDuration<T> {
+        fn validate_composited_maximum_duration(&self, minimum: T) -> Result<(), Composited<MaximumDurationError>>;
     }
 );
 

--- a/serde_valid/src/validation.rs
+++ b/serde_valid/src/validation.rs
@@ -5,6 +5,7 @@ mod generic;
 mod numeric;
 mod object;
 mod string;
+mod duration;
 
 use crate::{
     EnumerateError, ExclusiveMaximumError, ExclusiveMinimumError, MaxLengthError,
@@ -314,6 +315,7 @@ macro_rules! impl_generic_composited_validation_1args {
 }
 
 pub(crate) use impl_generic_composited_validation_1args;
+use crate::error::MinimumDurationError;
 
 // Number
 impl_composited_validation_1args!(
@@ -325,6 +327,12 @@ impl_composited_validation_1args!(
 impl_composited_validation_1args!(
     pub trait ValidateCompositedMinimum<T> {
         fn validate_composited_minimum(&self, minimum: T) -> Result<(), Composited<MinimumError>>;
+    }
+);
+
+impl_composited_validation_1args!(
+    pub trait ValidateCompositedMinimumDuration<T> {
+        fn validate_composited_duration(&self, minimum: T) -> Result<(), Composited<MinimumDurationError>>;
     }
 );
 

--- a/serde_valid/src/validation/composited.rs
+++ b/serde_valid/src/validation/composited.rs
@@ -6,6 +6,7 @@ use crate::error::{
     MinimumError, MultipleOfError, PatternError, UniqueItemsError,
 };
 use indexmap::IndexMap;
+use crate::validation::MinimumDurationError;
 
 /// Composited use Vec or Map error.
 ///
@@ -63,6 +64,7 @@ impl_into_error!(Minimum);
 impl_into_error!(ExclusiveMaximum);
 impl_into_error!(ExclusiveMinimum);
 impl_into_error!(MultipleOf);
+impl_into_error!(MinimumDuration);
 
 // String
 impl_into_error!(MaxLength);

--- a/serde_valid/src/validation/composited.rs
+++ b/serde_valid/src/validation/composited.rs
@@ -3,7 +3,7 @@ use crate::validation::error::IntoError;
 use crate::error::{
     EnumerateError, ExclusiveMaximumError, ExclusiveMinimumError, MaxItemsError, MaxLengthError,
     MaxPropertiesError, MaximumError, MinItemsError, MinLengthError, MinPropertiesError,
-    MinimumError, MultipleOfError, PatternError, UniqueItemsError,
+    MinimumError, MultipleOfError, PatternError, UniqueItemsError, MaximumDurationError
 };
 use indexmap::IndexMap;
 use crate::validation::MinimumDurationError;
@@ -65,6 +65,7 @@ impl_into_error!(ExclusiveMaximum);
 impl_into_error!(ExclusiveMinimum);
 impl_into_error!(MultipleOf);
 impl_into_error!(MinimumDuration);
+impl_into_error!(MaximumDuration);
 
 // String
 impl_into_error!(MaxLength);

--- a/serde_valid/src/validation/duration.rs
+++ b/serde_valid/src/validation/duration.rs
@@ -1,1 +1,2 @@
 mod minimum_duration;
+mod maximum_duration;

--- a/serde_valid/src/validation/duration.rs
+++ b/serde_valid/src/validation/duration.rs
@@ -1,0 +1,1 @@
+mod minimum_duration;

--- a/serde_valid/src/validation/duration/maximum_duration.rs
+++ b/serde_valid/src/validation/duration/maximum_duration.rs
@@ -1,0 +1,58 @@
+use crate::error::MaximumDurationError;
+use std::time::Duration;
+use crate::validation::{Composited, ValidateCompositedMaximumDuration};
+/// Maximum duration validation.
+/// Three suffix are allowed:
+/// - ns
+/// - ms
+/// - s
+///
+/// ```rust
+/// use std::time::Duration;
+/// use serde_json::json;
+/// use serde_valid::{Validate};
+///
+/// #[derive(Validate)]
+/// struct TestStruct {
+///     #[validate(maximum_duration = "10ns")]
+///     val: Duration,
+/// }
+///
+/// let s = TestStruct {
+///     val: Duration::from_millis(20),
+/// };
+///
+/// assert_eq!(
+///     s.validate().unwrap_err().to_string(),
+///     json!({
+///         "errors": [],
+///         "properties": {
+///             "val": {
+///                 "errors": ["The duration must be <= 0ms"]
+///             }
+///         }
+///     })
+///     .to_string()
+/// );
+/// ```
+pub trait ValidateMaximumDuration
+{
+    fn validate_minimum_duration(&self, minimum: Duration) -> Result<(), MaximumDurationError>;
+}
+
+impl ValidateMaximumDuration for Duration{
+    fn validate_minimum_duration(&self, maximum: Duration) -> Result<(), MaximumDurationError> {
+        if &maximum < self {
+            Err(MaximumDurationError::new(maximum))
+        }else {
+
+            Ok(())
+        }
+    }
+}
+
+impl ValidateCompositedMaximumDuration<Duration> for Duration{
+    fn validate_composited_maximum_duration(&self, limit: Duration) -> Result<(), Composited<MaximumDurationError>> {
+        self.validate_minimum_duration(limit).map_err(|error|Composited::Single(error))
+    }
+}

--- a/serde_valid/src/validation/duration/minimum_duration.rs
+++ b/serde_valid/src/validation/duration/minimum_duration.rs
@@ -1,0 +1,58 @@
+use crate::error::MinimumDurationError;
+use std::time::Duration;
+use crate::validation::{Composited, ValidateCompositedMinimumDuration};
+
+/// Minimum duration validation.
+/// Three suffix are allowed:
+/// - ns
+/// - ms
+/// - s
+///
+/// ```rust
+/// use std::time::Duration;
+/// use serde_json::json;
+/// use serde_valid::{Validate};
+///
+/// #[derive(Validate)]
+/// struct TestStruct {
+///     #[validate(minimum_duration = "30s")]
+///     val: Duration,
+/// }
+///
+/// let s = TestStruct {
+///     val: Duration::from_millis(20),
+/// };
+///
+/// assert_eq!(
+///     s.validate().unwrap_err().to_string(),
+///     json!({
+///         "errors": [],
+///         "properties": {
+///             "val": {
+///                 "errors": ["The duration must be >= 30000ms"]
+///             }
+///         }
+///     })
+///     .to_string()
+/// );
+/// ```
+pub trait ValidateMinimumDuration
+{
+    fn validate_minimum_duration(&self, minimum: Duration) -> Result<(), MinimumDurationError>;
+}
+
+impl ValidateMinimumDuration for Duration{
+    fn validate_minimum_duration(&self, minimum: Duration) -> Result<(), MinimumDurationError> {
+        if &minimum > self {
+            Err(MinimumDurationError::new(minimum))
+        }else {
+            Ok(())
+        }
+    }
+}
+
+impl ValidateCompositedMinimumDuration<Duration> for Duration{
+    fn validate_composited_duration(&self, limit: Duration) -> Result<(), Composited<MinimumDurationError>> {
+        self.validate_minimum_duration(limit).map_err(|error|Composited::Single(error))
+    }
+}

--- a/serde_valid/src/validation/error.rs
+++ b/serde_valid/src/validation/error.rs
@@ -17,6 +17,7 @@ use indexmap::IndexMap;
 pub use into_error::IntoError;
 pub use message::Message;
 pub use object_errors::ObjectErrors;
+use crate::error::MinimumDurationError;
 
 #[derive(Debug, Clone, serde::Serialize, thiserror::Error)]
 #[serde(untagged)]
@@ -91,6 +92,10 @@ pub enum Error {
     #[error("{0}")]
     #[serde(serialize_with = "serialize_error_message")]
     Fluent(crate::fluent::Message),
+
+    #[error("{0}")]
+    #[serde(serialize_with = "serialize_error_message")]
+    MinimumDuration(Message<MinimumDurationError>),
 }
 
 fn serialize_error_message<T, S>(message: &T, serializer: S) -> Result<S::Ok, S::Error>

--- a/serde_valid/src/validation/error.rs
+++ b/serde_valid/src/validation/error.rs
@@ -17,7 +17,7 @@ use indexmap::IndexMap;
 pub use into_error::IntoError;
 pub use message::Message;
 pub use object_errors::ObjectErrors;
-use crate::error::MinimumDurationError;
+use crate::error::{MaximumDurationError, MinimumDurationError};
 
 #[derive(Debug, Clone, serde::Serialize, thiserror::Error)]
 #[serde(untagged)]
@@ -96,6 +96,10 @@ pub enum Error {
     #[error("{0}")]
     #[serde(serialize_with = "serialize_error_message")]
     MinimumDuration(Message<MinimumDurationError>),
+
+    #[error("{0}")]
+    #[serde(serialize_with = "serialize_error_message")]
+    MaximumDuration(Message<MaximumDurationError>),
 }
 
 fn serialize_error_message<T, S>(message: &T, serializer: S) -> Result<S::Ok, S::Error>

--- a/serde_valid/tests/complex_test.rs
+++ b/serde_valid/tests/complex_test.rs
@@ -135,6 +135,7 @@ struct TestInnerStruct<'a> {
     inner_vec_value: Vec<i32>,
 
     #[validate(minimum_duration = "15ms")]
+    #[validate(maximum_duration = "60ms")]
     inner_duration: Duration
 }
 

--- a/serde_valid/tests/complex_test.rs
+++ b/serde_valid/tests/complex_test.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use serde_valid::Validate;
 
 fn sample_rule(_val: &i32) -> Result<(), serde_valid::validation::Error> {
@@ -132,6 +133,9 @@ struct TestInnerStruct<'a> {
     #[validate(minimum = 5)]
     #[validate(maximum = 15)]
     inner_vec_value: Vec<i32>,
+
+    #[validate(minimum_duration = "15ms")]
+    inner_duration: Duration
 }
 
 #[test]
@@ -150,6 +154,7 @@ fn complex_validation() {
             inner_str_value: "12345",
             inner_optional_value: Some(5),
             inner_vec_value: vec![5, 10, 15],
+            inner_duration: Duration::from_millis(16)
         },
         nested_vec_struct: vec![TestInnerStruct {
             inner_int_value: 5,
@@ -158,6 +163,7 @@ fn complex_validation() {
             inner_str_value: "12345",
             inner_optional_value: Some(5),
             inner_vec_value: vec![5, 10, 15],
+            inner_duration:Duration::from_millis(56)
         }],
     };
     assert!(s.validate().is_ok());

--- a/serde_valid_derive/src/attribute.rs
+++ b/serde_valid_derive/src/attribute.rs
@@ -118,6 +118,7 @@ enum_str! {
         MultipleOf = "multiple_of",
         Pattern = "pattern",
         MinimumDuration = "minimum_duration",
+        MaximumDuration = "maximum_duration",
     }
 }
 

--- a/serde_valid_derive/src/attribute.rs
+++ b/serde_valid_derive/src/attribute.rs
@@ -117,6 +117,7 @@ enum_str! {
         MaxProperties = "max_properties",
         MultipleOf = "multiple_of",
         Pattern = "pattern",
+        MinimumDuration = "minimum_duration",
     }
 }
 

--- a/serde_valid_derive/src/attribute/field_validate.rs
+++ b/serde_valid_derive/src/attribute/field_validate.rs
@@ -5,6 +5,7 @@ mod meta;
 mod numeric;
 mod object;
 mod string;
+mod duration;
 
 pub use field::FieldValidators;
 pub use meta::extract_field_validator;

--- a/serde_valid_derive/src/attribute/field_validate/duration.rs
+++ b/serde_valid_derive/src/attribute/field_validate/duration.rs
@@ -1,0 +1,42 @@
+pub mod minimum_duration;
+
+use std::str::FromStr;
+use proc_macro2::TokenStream;
+use quote::quote;
+pub use minimum_duration::extract_string_minimum_duration_validator;
+use crate::attribute::common::lit::get_str;
+use crate::error::Error;
+
+fn extract_duration(value: &syn::Lit) -> Result<TokenStream, crate::Errors> {
+    let pattern = get_str(value)?.value();
+    if let Some(index) = pattern.find(char::is_alphabetic) {
+        let test = &pattern[index..];
+        let number = u64::from_str(&pattern[..index]).map_err(|_| crate::Errors::new())?;
+        match test {
+            "ns" => {
+                Ok(
+                    quote!(
+                            let duration = Duration::from_nanos(#number);
+                        )
+                )
+            }
+            "ms" => {
+                Ok(
+                    quote!(
+                            let duration = Duration::from_millis(#number);
+                        )
+                )
+            }
+            "s" => {
+                Ok(
+                    quote!(
+                            let duration = Duration::from_secs(#number);
+                        )
+                )
+            }
+            _ => {
+                Err(vec![Error::duration_str_wrong_suffix(&value, &["ns", "ms", "s"])])
+            }
+        }
+    } else { Err(vec![Error::duration_str_no_suffix(&value)]) }
+}

--- a/serde_valid_derive/src/attribute/field_validate/duration.rs
+++ b/serde_valid_derive/src/attribute/field_validate/duration.rs
@@ -1,4 +1,5 @@
 pub mod minimum_duration;
+pub mod maximum_duration;
 
 use std::str::FromStr;
 use proc_macro2::TokenStream;

--- a/serde_valid_derive/src/attribute/field_validate/duration/maximum_duration.rs
+++ b/serde_valid_derive/src/attribute/field_validate/duration/maximum_duration.rs
@@ -1,0 +1,47 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use crate::attribute::common::message_format::MessageFormat;
+use crate::attribute::field_validate::duration::extract_duration;
+use crate::attribute::Validator;
+use crate::serde::rename::RenameMap;
+use crate::types::Field;
+
+pub fn extract_string_maximum_duration_validator(
+    field: &impl Field,
+    validation_value: &syn::Lit,
+    message_format: MessageFormat,
+    rename_map: &RenameMap,
+) -> Result<Validator, crate::Errors> {
+    inner_extract_string_duration_validator(field, validation_value, message_format, rename_map)
+}
+
+fn inner_extract_string_duration_validator(
+    field: &impl Field,
+    validation_value: &syn::Lit,
+    message_format: MessageFormat,
+    rename_map: &RenameMap,
+) -> Result<TokenStream, crate::Errors> {
+
+    let field_name = field.name();
+    let field_ident = field.ident();
+    let field_key = field.key();
+    let rename = rename_map.get(field_name).unwrap_or(&field_key);
+    let errors = field.errors_variable();
+    let duration = extract_duration(validation_value)?;
+
+    Ok(quote!(
+        #duration
+        if let Err(__composited_error_params) = ::serde_valid::validation::ValidateCompositedMaximumDuration::validate_composited_maximum_duration(
+            #field_ident,
+            duration,
+        ) {
+            use ::serde_valid::validation::IntoError;
+            use ::serde_valid::validation::error::FormatDefault;
+
+            #errors
+                .entry(#rename)
+                .or_default()
+                .push(__composited_error_params.into_error_by(#message_format));
+        }
+    ))
+}

--- a/serde_valid_derive/src/attribute/field_validate/duration/minimum_duration.rs
+++ b/serde_valid_derive/src/attribute/field_validate/duration/minimum_duration.rs
@@ -1,0 +1,46 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use crate::attribute::common::message_format::MessageFormat;
+use crate::attribute::field_validate::duration::extract_duration;
+use crate::attribute::Validator;
+use crate::serde::rename::RenameMap;
+use crate::types::Field;
+
+pub fn extract_string_minimum_duration_validator(
+    field: &impl Field,
+    validation_value: &syn::Lit,
+    message_format: MessageFormat,
+    rename_map: &RenameMap,
+) -> Result<Validator, crate::Errors> {
+    inner_extract_string_duration_validator(field, validation_value, message_format, rename_map)
+}
+
+fn inner_extract_string_duration_validator(
+    field: &impl Field,
+    validation_value: &syn::Lit,
+    message_format: MessageFormat,
+    rename_map: &RenameMap,
+) -> Result<TokenStream, crate::Errors> {
+    let field_name = field.name();
+    let field_ident = field.ident();
+    let field_key = field.key();
+    let rename = rename_map.get(field_name).unwrap_or(&field_key);
+    let errors = field.errors_variable();
+    let duration = extract_duration(&validation_value)?;
+
+    Ok(quote!(
+        #duration
+        if let Err(__composited_error_params) = ::serde_valid::validation::ValidateCompositedMinimumDuration::validate_composited_duration(
+            #field_ident,
+            duration,
+        ) {
+            use ::serde_valid::validation::IntoError;
+            use ::serde_valid::validation::error::FormatDefault;
+
+            #errors
+                .entry(#rename)
+                .or_default()
+                .push(__composited_error_params.into_error_by(#message_format));
+        }
+    ))
+}

--- a/serde_valid_derive/src/attribute/field_validate/meta/meta_name_value.rs
+++ b/serde_valid_derive/src/attribute/field_validate/meta/meta_name_value.rs
@@ -14,6 +14,7 @@ use crate::attribute::field_validate::object::{
 use crate::attribute::field_validate::string::{extract_string_max_length_validator, extract_string_min_length_validator, extract_string_pattern_validator};
 use crate::attribute::{MetaNameValueFieldValidation, Validator};
 use crate::attribute::field_validate::duration::extract_string_minimum_duration_validator;
+use crate::attribute::field_validate::duration::maximum_duration::extract_string_maximum_duration_validator;
 use crate::serde::rename::RenameMap;
 use crate::types::Field;
 
@@ -84,6 +85,9 @@ pub fn extract_field_validator_from_meta_name_value(
         },
         MetaNameValueFieldValidation::MinimumDuration =>{
             extract_string_minimum_duration_validator(field, validation_value, message_format, rename_map)
+        },
+        MetaNameValueFieldValidation::MaximumDuration =>{
+            extract_string_maximum_duration_validator(field, validation_value, message_format, rename_map)
         }
     }
 }

--- a/serde_valid_derive/src/attribute/field_validate/meta/meta_name_value.rs
+++ b/serde_valid_derive/src/attribute/field_validate/meta/meta_name_value.rs
@@ -11,11 +11,9 @@ use crate::attribute::field_validate::numeric::{
 use crate::attribute::field_validate::object::{
     extract_object_max_properties_validator, extract_object_min_properties_validator,
 };
-use crate::attribute::field_validate::string::{
-    extract_string_max_length_validator, extract_string_min_length_validator,
-    extract_string_pattern_validator,
-};
+use crate::attribute::field_validate::string::{extract_string_max_length_validator, extract_string_min_length_validator, extract_string_pattern_validator};
 use crate::attribute::{MetaNameValueFieldValidation, Validator};
+use crate::attribute::field_validate::duration::extract_string_minimum_duration_validator;
 use crate::serde::rename::RenameMap;
 use crate::types::Field;
 
@@ -83,6 +81,9 @@ pub fn extract_field_validator_from_meta_name_value(
         ),
         MetaNameValueFieldValidation::Pattern => {
             extract_string_pattern_validator(field, validation_value, message_format, rename_map)
+        },
+        MetaNameValueFieldValidation::MinimumDuration =>{
+            extract_string_minimum_duration_validator(field, validation_value, message_format, rename_map)
         }
     }
 }

--- a/serde_valid_derive/src/error.rs
+++ b/serde_valid_derive/src/error.rs
@@ -457,6 +457,15 @@ impl Error {
         Self::new(lit.span(), "Allow str literal only.")
     }
 
+    pub fn duration_str_no_suffix(lit: &syn::Lit) -> Self{
+        Self::new(lit.span(), "No suffix found.")
+    }
+
+    pub fn duration_str_wrong_suffix(lit: &syn::Lit, suffix_allowed: &[&str]) -> Self{
+        Self::new(lit.span(), format!("Wrong suffix found (allowed: {})",
+                                      suffix_allowed.iter().fold(String::new(), |acc, &arg| acc + "," + arg)))
+    }
+
     pub fn closure_not_supported(closure: &syn::ExprClosure) -> Self {
         Self::new(
             closure.or1_token.span(),


### PR DESCRIPTION
With the help of some crate like `serde_with`, it is possible to serialize and deserialize Duration.

With modification `serde_valid` is able to define `minimum` and `maximum` for this type. 
To define such minimum, we use the attribute validate with the parameter `minimum_duration` like this 
`#[validate(minimum_duration="10ms")]`, "10ms" is transformed into `Duration::from_millis(10)`.

We can also use `s` and `ns` prefix