### PR TITLE
serde_yaml to serde_yml switch

### DIFF
--- a/serde_valid/Cargo.toml
+++ b/serde_valid/Cargo.toml
@@ -24,7 +24,7 @@ serde_json.workspace = true
 serde_toml = { package = "toml", version = "^0.8", optional = true }
 serde_valid_derive = { version = "0.24.0", path = "../serde_valid_derive" }
 serde_valid_literal = { version = "0.24.0", path = "../serde_valid_literal" }
-serde_yaml = { version = "^0.9", optional = true }
+serde_yml = { version = "^0.0", optional = true }
 thiserror = "^1.0"
 unicode-segmentation = "^1.7"
 
@@ -35,6 +35,6 @@ unic-langid = "0.9"
 [features]
 default = ["i128"]
 toml = ["serde_toml"]
-yaml = ["serde_yaml"]
+yaml = ["serde_yml"]
 i128 = ["num-traits/i128", "indexmap/std", "serde_valid_literal/i128"]
 fluent = ["dep:fluent", "serde_valid_derive/fluent"]

--- a/serde_valid/src/features/yaml.rs
+++ b/serde_valid/src/features/yaml.rs
@@ -6,7 +6,7 @@ mod to_yaml_string;
 mod to_yaml_value;
 mod to_yaml_writer;
 
-pub use serde_yaml::{Error, Index, Location, Mapping, Number, Sequence, Value};
+pub use serde_yml::{Error, Index, Location, Mapping, Number, Sequence, Value};
 
 pub use from_yaml_reader::FromYamlReader;
 pub use from_yaml_slice::FromYamlSlice;

--- a/serde_valid/src/features/yaml/from_yaml_reader.rs
+++ b/serde_valid/src/features/yaml/from_yaml_reader.rs
@@ -20,7 +20,7 @@ where
     ///
     /// assert!(s.is_ok())
     /// ```
-    fn from_yaml_reader<R>(reader: R) -> Result<Self, crate::Error<serde_yaml::Error>>
+    fn from_yaml_reader<R>(reader: R) -> Result<Self, crate::Error<serde_yml::Error>>
     where
         R: std::io::Read;
 }
@@ -30,11 +30,11 @@ where
     for<'de> T: serde::de::Deserialize<'de>,
     T: crate::Validate,
 {
-    fn from_yaml_reader<R>(reader: R) -> Result<Self, crate::Error<serde_yaml::Error>>
+    fn from_yaml_reader<R>(reader: R) -> Result<Self, crate::Error<serde_yml::Error>>
     where
         R: std::io::Read,
     {
-        let model: T = serde_yaml::from_reader(reader)?;
+        let model: T = serde_yml::from_reader(reader)?;
         model.validate().map_err(crate::Error::ValidationError)?;
         Ok(model)
     }

--- a/serde_valid/src/features/yaml/from_yaml_slice.rs
+++ b/serde_valid/src/features/yaml/from_yaml_slice.rs
@@ -19,15 +19,15 @@ where
     ///
     /// assert!(s.is_ok())
     /// ```
-    fn from_yaml_slice(slice: &'de [u8]) -> Result<Self, crate::Error<serde_yaml::Error>>;
+    fn from_yaml_slice(slice: &'de [u8]) -> Result<Self, crate::Error<serde_yml::Error>>;
 }
 
 impl<'de, T> FromYamlSlice<'de> for T
 where
     T: serde::de::Deserialize<'de> + crate::Validate,
 {
-    fn from_yaml_slice(slice: &'de [u8]) -> Result<Self, crate::Error<serde_yaml::Error>> {
-        let model: T = serde_yaml::from_slice(slice)?;
+    fn from_yaml_slice(slice: &'de [u8]) -> Result<Self, crate::Error<serde_yml::Error>> {
+        let model: T = serde_yml::from_slice(slice)?;
         model.validate().map_err(crate::Error::ValidationError)?;
         Ok(model)
     }

--- a/serde_valid/src/features/yaml/from_yaml_str.rs
+++ b/serde_valid/src/features/yaml/from_yaml_str.rs
@@ -19,15 +19,15 @@ where
     ///
     /// assert!(s.is_ok())
     /// ```
-    fn from_yaml_str(str: &'de str) -> Result<Self, crate::Error<serde_yaml::Error>>;
+    fn from_yaml_str(str: &'de str) -> Result<Self, crate::Error<serde_yml::Error>>;
 }
 
 impl<'de, T> FromYamlStr<'de> for T
 where
     T: serde::de::Deserialize<'de> + crate::Validate,
 {
-    fn from_yaml_str(str: &'de str) -> Result<Self, crate::Error<serde_yaml::Error>> {
-        let model: T = serde_yaml::from_str(str)?;
+    fn from_yaml_str(str: &'de str) -> Result<Self, crate::Error<serde_yml::Error>> {
+        let model: T = serde_yml::from_str(str)?;
         model.validate().map_err(crate::Error::ValidationError)?;
         Ok(model)
     }

--- a/serde_valid/src/features/yaml/from_yaml_value.rs
+++ b/serde_valid/src/features/yaml/from_yaml_value.rs
@@ -2,7 +2,7 @@ pub trait FromYamlValue
 where
     Self: Sized,
 {
-    /// Convert from [`serde_yaml::Value`](serde_yaml::Value).
+    /// Convert from [`serde_yml::Value`](serde_yml::Value).
     ///
     /// ```rust
     /// use serde::Deserialize;
@@ -15,19 +15,19 @@ where
     ///     val: i32,
     /// }
     ///
-    /// let s = TestStruct::from_yaml_value(serde_yaml::from_str("val: 5").unwrap());
+    /// let s = TestStruct::from_yaml_value(serde_yml::from_str("val: 5").unwrap());
     ///
     /// assert!(s.is_ok())
     /// ```
-    fn from_yaml_value(value: serde_yaml::Value) -> Result<Self, crate::Error<serde_yaml::Error>>;
+    fn from_yaml_value(value: serde_yml::Value) -> Result<Self, crate::Error<serde_yml::Error>>;
 }
 
 impl<T> FromYamlValue for T
 where
     T: serde::de::DeserializeOwned + crate::Validate,
 {
-    fn from_yaml_value(value: serde_yaml::Value) -> Result<Self, crate::Error<serde_yaml::Error>> {
-        let model: T = serde_yaml::from_value(value)?;
+    fn from_yaml_value(value: serde_yml::Value) -> Result<Self, crate::Error<serde_yml::Error>> {
+        let model: T = serde_yml::from_value(value)?;
         model.validate().map_err(crate::Error::ValidationError)?;
         Ok(model)
     }

--- a/serde_valid/src/features/yaml/to_yaml_string.rs
+++ b/serde_valid/src/features/yaml/to_yaml_string.rs
@@ -15,20 +15,20 @@ pub trait ToYamlString {
     ///
     /// assert!(s.to_yaml_string().is_ok());
     /// ```
-    fn to_yaml_string(&self) -> Result<String, serde_yaml::Error>;
+    fn to_yaml_string(&self) -> Result<String, serde_yml::Error>;
 }
 
 impl<T> ToYamlString for T
 where
     T: serde::Serialize + crate::Validate,
 {
-    fn to_yaml_string(&self) -> Result<String, serde_yaml::Error> {
-        serde_yaml::to_string(self)
+    fn to_yaml_string(&self) -> Result<String, serde_yml::Error> {
+        serde_yml::to_string(self)
     }
 }
 
-impl ToYamlString for serde_yaml::Value {
-    fn to_yaml_string(&self) -> Result<String, serde_yaml::Error> {
-        serde_yaml::to_string(self)
+impl ToYamlString for serde_yml::Value {
+    fn to_yaml_string(&self) -> Result<String, serde_yml::Error> {
+        serde_yml::to_string(self)
     }
 }

--- a/serde_valid/src/features/yaml/to_yaml_value.rs
+++ b/serde_valid/src/features/yaml/to_yaml_value.rs
@@ -15,14 +15,14 @@ pub trait ToYamlValue {
     ///
     /// assert!(s.to_yaml_value().is_ok());
     /// ```
-    fn to_yaml_value(&self) -> Result<serde_yaml::Value, serde_yaml::Error>;
+    fn to_yaml_value(&self) -> Result<serde_yml::Value, serde_yml::Error>;
 }
 
 impl<T> ToYamlValue for T
 where
     T: serde::Serialize + crate::Validate,
 {
-    fn to_yaml_value(&self) -> Result<serde_yaml::Value, serde_yaml::Error> {
-        serde_yaml::to_value(self)
+    fn to_yaml_value(&self) -> Result<serde_yml::Value, serde_yml::Error> {
+        serde_yml::to_value(self)
     }
 }

--- a/serde_valid/src/features/yaml/to_yaml_writer.rs
+++ b/serde_valid/src/features/yaml/to_yaml_writer.rs
@@ -16,7 +16,7 @@ pub trait ToYamlWriter {
     ///
     /// assert!(s.to_yaml_writer(File::open("foo.txt").unwrap()).is_ok());
     /// ```
-    fn to_yaml_writer<W>(&self, writer: W) -> Result<(), serde_yaml::Error>
+    fn to_yaml_writer<W>(&self, writer: W) -> Result<(), serde_yml::Error>
     where
         W: std::io::Write;
 }
@@ -25,19 +25,19 @@ impl<T> ToYamlWriter for T
 where
     T: serde::Serialize + crate::Validate,
 {
-    fn to_yaml_writer<W>(&self, writer: W) -> Result<(), serde_yaml::Error>
+    fn to_yaml_writer<W>(&self, writer: W) -> Result<(), serde_yml::Error>
     where
         W: std::io::Write,
     {
-        serde_yaml::to_writer(writer, self)
+        serde_yml::to_writer(writer, self)
     }
 }
 
-impl ToYamlWriter for serde_yaml::Value {
-    fn to_yaml_writer<W>(&self, writer: W) -> Result<(), serde_yaml::Error>
+impl ToYamlWriter for serde_yml::Value {
+    fn to_yaml_writer<W>(&self, writer: W) -> Result<(), serde_yml::Error>
     where
         W: std::io::Write,
     {
-        serde_yaml::to_writer(writer, self)
+        serde_yml::to_writer(writer, self)
     }
 }

--- a/serde_valid/tests/deserialize_test.rs
+++ b/serde_valid/tests/deserialize_test.rs
@@ -64,7 +64,7 @@ fn yaml_error_as_validation_errors() {
         val: i32,
     }
 
-    let err = TestStruct::from_yaml_value(serde_yaml::from_str("val: 15").unwrap()).unwrap_err();
+    let err = TestStruct::from_yaml_value(serde_yml::from_str("val: 15").unwrap()).unwrap_err();
 
     assert_eq!(
         serde_json::to_value(err.as_validation_errors().unwrap()).unwrap(),


### PR DESCRIPTION
As the `serde_yaml` project has been archived and the crate marked as deprecated, I've switched the code base to use the `serde_yml` project and crate as it seems to now be the successor.

This PR addresses [this issue](https://github.com/yassun7010/serde_valid/issues/80)