### PR TITLE
Fix invalid custom test case

### DIFF
--- a/serde_valid/src/validation/custom.rs
+++ b/serde_valid/src/validation/custom.rs
@@ -55,17 +55,13 @@ mod test {
     fn test_custom_fn_multiple_errors() {
         fn multiple_errors(data: &i32) -> Result<(), Vec<crate::validation::Error>> {
             let mut errors = Vec::new();
-            if *data > 0 {
-                return Ok(());
-            } else {
+            if *data < 1 {
                 errors.push(crate::validation::Error::Custom(
                     "Value must be greater than 0".to_string(),
                 ));
             }
 
-            if *data < 10 {
-                return Ok(());
-            } else {
+            if *data >= 10 {
                 errors.push(crate::validation::Error::Custom(
                     "Value must be less than 10".to_string(),
                 ));

--- a/serde_valid/src/validation/custom.rs
+++ b/serde_valid/src/validation/custom.rs
@@ -47,6 +47,8 @@ mod test {
         }
 
         assert!(wrap_closure_validation(&1i32, single_error).is_ok());
+        assert!(wrap_closure_validation(&0i32, single_error).is_err());
+        assert!(wrap_closure_validation(&-1i32, single_error).is_err());
     }
 
     #[test]
@@ -77,5 +79,9 @@ mod test {
         }
 
         assert!(wrap_closure_validation(&1i32, multiple_errors).is_ok());
+        assert!(wrap_closure_validation(&10i32, multiple_errors).is_err());
+        assert!(wrap_closure_validation(&11i32, multiple_errors).is_err());
+        assert!(wrap_closure_validation(&0i32, multiple_errors).is_err());
+        assert!(wrap_closure_validation(&-1i32, multiple_errors).is_err());
     }
 }


### PR DESCRIPTION
# Summary

There is a logical fault in one of the custom test cases. It returned after one of the conditions was checked, not both. Fix it by not returning Ok on the first condition. It is done as a quick fix by removing the first case and inverting the tests, as I am not aware of the repository preferences.

As a bonus, add unhappy test cases to both of the custom tests to catch similar in the future.