### PR TITLE
chore: address RUSTSEC-2024-0436 by switching from paste to pastey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["json_schema", "serde", "validation"]
 
 [workspace.dependencies]
 itertools = "^0.14.0"
-paste = "^1.0"
+pastey = "^0.2.1"
 proc-macro-error2 = { version = "^2.0", default-features = false }
 proc-macro2 = "^1.0"
 quote = "^1.0"

--- a/crates/serde_valid/Cargo.toml
+++ b/crates/serde_valid/Cargo.toml
@@ -16,7 +16,7 @@ indexmap = { version = "^2.0", features = ["serde"] }
 itertools.workspace = true
 num-traits = "^0.2"
 once_cell = "^1.7"
-paste.workspace = true
+pastey.workspace = true
 regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/serde_valid/src/validation.rs
+++ b/crates/serde_valid/src/validation.rs
@@ -38,7 +38,7 @@ macro_rules! impl_composited_validation_1args {
             ) -> Result<(), Composited<$Error:ty>>;
         }
     ) => {
-        paste::paste! {
+        pastey::paste! {
             pub trait $ValidateCompositedTrait {
                 fn $validate_composited_method(
                     &self,
@@ -149,7 +149,7 @@ macro_rules! impl_composited_validation_1args {
                 ) -> Result<(), Composited<$Error>>;
             }
         );
-        paste::paste! {
+        pastey::paste! {
             impl<K, V> $ValidateCompositedTrait2 for std::collections::HashMap<K, V>
             where
                 V: $ValidateCompositedTrait3,
@@ -297,7 +297,7 @@ macro_rules! impl_generic_composited_validation_1args {
         $ErrorType:ident,
         $type:ty
     ) => {
-        paste::paste! {
+        pastey::paste! {
             impl<T> [<ValidateComposited $ErrorType >]<$type> for T
             where
                 T: [<Validate $ErrorType >]<$type>,

--- a/crates/serde_valid/src/validation/array.rs
+++ b/crates/serde_valid/src/validation/array.rs
@@ -10,7 +10,7 @@ use crate::{MaxItemsError, MinItemsError};
 
 macro_rules! impl_validate_array_length_items {
     ($ErrorType:ident) => {
-        paste::paste! {
+        pastey::paste! {
             impl<T> [<Validate $ErrorType>] for Option<T>
             where
                 T: [<Validate $ErrorType>],

--- a/crates/serde_valid/src/validation/composited.rs
+++ b/crates/serde_valid/src/validation/composited.rs
@@ -30,7 +30,7 @@ pub enum Composited<Error> {
 
 macro_rules! impl_into_error {
     ($ErrorType:ident) => {
-        paste::paste! {
+        pastey::paste! {
             impl IntoError<[<$ErrorType Error>]> for Composited<[<$ErrorType Error>]> {
                 fn into_error_by(self, format: crate::validation::error::Format<[<$ErrorType Error>]>) -> crate::validation::error::Error {
                     match self {

--- a/crates/serde_valid_derive/Cargo.toml
+++ b/crates/serde_valid_derive/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 
 [dependencies]
 itertools.workspace = true
-paste.workspace = true
+pastey.workspace = true
 proc-macro-error2 = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }

--- a/crates/serde_valid_derive/src/attribute/field_validate/array/length_items.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/array/length_items.rs
@@ -11,7 +11,7 @@ use quote::quote;
 /// See <https://json-schema.org/understanding-json-schema/reference/array.html#length>
 macro_rules! extract_array_length_validator{
     ($ErrorType:ident) => {
-        paste::paste! {
+        pastey::paste! {
             pub fn [<extract_array_ $ErrorType:snake _validator>](
                 field: &impl Field,
                 validation_value: &syn::Lit,

--- a/crates/serde_valid_derive/src/attribute/field_validate/numeric/range.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/numeric/range.rs
@@ -10,7 +10,7 @@ use quote::quote;
 /// See <https://json-schema.org/understanding-json-schema/reference/numeric.html#range>
 macro_rules! extract_numeric_range_validator{
     ($ErrorType:ident) => {
-        paste::paste! {
+        pastey::paste! {
             pub fn [<extract_numeric_ $ErrorType:snake _validator>](
                 field: &impl Field,
                 validation_value: &syn::Expr,

--- a/crates/serde_valid_derive/src/attribute/field_validate/object/size_properties.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/object/size_properties.rs
@@ -11,7 +11,7 @@ use quote::quote;
 /// See <https://json-schema.org/understanding-json-schema/reference/object.html#size>
 macro_rules! extract_object_size_validator {
     ($ErrorType:ident) => {
-        paste::paste! {
+        pastey::paste! {
             pub fn [<extract_object_ $ErrorType:snake _validator>](
                 field: &impl Field,
                 validation_value: &syn::Lit,

--- a/crates/serde_valid_derive/src/attribute/field_validate/string/length.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/string/length.rs
@@ -11,7 +11,7 @@ use quote::quote;
 /// See <https://json-schema.org/understanding-json-schema/reference/string.html#length>
 macro_rules! extract_string_length_validator{
     ($ErrorType:ident) => {
-        paste::paste! {
+        pastey::paste! {
             pub fn [<extract_string_ $ErrorType:snake _validator>](
                 field: &impl Field,
                 validation_value: &syn::Lit,

--- a/crates/serde_valid_literal/Cargo.toml
+++ b/crates/serde_valid_literal/Cargo.toml
@@ -12,7 +12,7 @@ categories = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-paste = { workspace = true }
+pastey = { workspace = true }
 regex = { workspace = true }
 
 [features]

--- a/crates/serde_valid_literal/src/number.rs
+++ b/crates/serde_valid_literal/src/number.rs
@@ -78,7 +78,7 @@ impl std::fmt::Display for Number {
 
 macro_rules! impl_from_trait {
     ($type:ty) => {
-        paste::paste! {
+        pastey::paste! {
             impl From<$type> for Number {
                 fn from(item: $type) -> Self {
                     Number::[<$type:camel>](item)


### PR DESCRIPTION
Switch from the paste create to the pastey crate, due to cargo audit idenitfying paste as unmaintained, per [RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436.html).

RUSTSEC-2024-0436 also mentions that pastey is a drop-in replacement.