### PR TITLE
refactor: remove paste dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["json_schema", "serde", "validation"]
 
 [workspace.dependencies]
 itertools = "^0.14.0"
-paste = "^1.0"
 proc-macro2 = "^1.0"
 quote = "^1.0"
 regex = "^1.12"

--- a/crates/serde_valid/Cargo.toml
+++ b/crates/serde_valid/Cargo.toml
@@ -16,7 +16,6 @@ indexmap = { version = "^2.0", features = ["serde"] }
 itertools.workspace = true
 num-traits = "^0.2"
 once_cell = "^1.7"
-paste.workspace = true
 regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/serde_valid/src/validation.rs
+++ b/crates/serde_valid/src/validation.rs
@@ -36,94 +36,93 @@ macro_rules! impl_composited_validation_1args {
                 $limit:ident: $limit_type:ty$(,)*
             ) -> Result<(), Composited<$Error:ty>>;
         }
+        via $ValidateTrait:ident::$validate_method:ident;
     ) => {
-        paste::paste! {
-            pub trait $ValidateCompositedTrait {
-                fn $validate_composited_method(
-                    &self,
-                    $limit: $limit_type
-                ) -> Result<(), Composited<$Error>>;
-            }
+        pub trait $ValidateCompositedTrait {
+            fn $validate_composited_method(
+                &self,
+                $limit: $limit_type
+            ) -> Result<(), Composited<$Error>>;
+        }
 
-            impl<T> $ValidateCompositedTrait for T
-            where
-                T: [<Validate $limit:camel>],
-            {
-                fn $validate_composited_method(
-                    &self,
-                    $limit: $limit_type,
-                ) -> Result<(), Composited<$Error>> {
-                    self.[<validate_ $limit>]($limit)
-                        .map_err(|error| Composited::Single(error))
+        impl<T> $ValidateCompositedTrait for T
+        where
+            T: $ValidateTrait,
+        {
+            fn $validate_composited_method(
+                &self,
+                $limit: $limit_type,
+            ) -> Result<(), Composited<$Error>> {
+                self.$validate_method($limit)
+                    .map_err(|error| Composited::Single(error))
+            }
+        }
+
+        impl<T> $ValidateCompositedTrait for Vec<T>
+        where
+            T: $ValidateCompositedTrait,
+        {
+            fn $validate_composited_method(
+                &self,
+                $limit: $limit_type,
+            ) -> Result<(), Composited<$Error>> {
+                let errors: IndexMap<usize, crate::validation::Composited<$Error>> = self
+                    .iter()
+                    .enumerate()
+                    .filter_map(
+                        |(index, item)| match item.$validate_composited_method($limit) {
+                            Ok(_) => None,
+                            Err(error) => Some((index, error)),
+                        },
+                    )
+                    .collect();
+
+                if errors.is_empty() {
+                    Ok(())
+                } else {
+                    Err(Composited::Array(errors))
                 }
             }
+        }
 
-            impl<T> $ValidateCompositedTrait for Vec<T>
-            where
-                T: $ValidateCompositedTrait,
-            {
-                fn $validate_composited_method(
-                    &self,
-                    $limit: $limit_type,
-                ) -> Result<(), Composited<$Error>> {
-                    let errors: IndexMap<usize, crate::validation::Composited<$Error>> = self
-                        .iter()
-                        .enumerate()
-                        .filter_map(
-                            |(index, item)| match item.$validate_composited_method($limit) {
-                                Ok(_) => None,
-                                Err(error) => Some((index, error)),
-                            },
-                        )
-                        .collect();
+        impl<T, const N: usize> $ValidateCompositedTrait for [T; N]
+        where
+            T: $ValidateCompositedTrait,
+        {
+            fn $validate_composited_method(
+                &self,
+                $limit: $limit_type,
+            ) -> Result<(), Composited<$Error>> {
+                let errors: IndexMap<usize, crate::validation::Composited<$Error>> = self
+                    .iter()
+                    .enumerate()
+                    .filter_map(
+                        |(index, item)| match item.$validate_composited_method($limit) {
+                            Ok(_) => None,
+                            Err(error) => Some((index, error)),
+                        },
+                    )
+                    .collect();
 
-                    if errors.is_empty() {
-                        Ok(())
-                    } else {
-                        Err(Composited::Array(errors))
-                    }
+                if errors.is_empty() {
+                    Ok(())
+                } else {
+                    Err(Composited::Array(errors))
                 }
             }
+        }
 
-            impl<T, const N: usize> $ValidateCompositedTrait for [T; N]
-            where
-                T: $ValidateCompositedTrait,
-            {
-                fn $validate_composited_method(
-                    &self,
-                    $limit: $limit_type,
-                ) -> Result<(), Composited<$Error>> {
-                    let errors: IndexMap<usize, crate::validation::Composited<$Error>> = self
-                        .iter()
-                        .enumerate()
-                        .filter_map(
-                            |(index, item)| match item.$validate_composited_method($limit) {
-                                Ok(_) => None,
-                                Err(error) => Some((index, error)),
-                            },
-                        )
-                        .collect();
-
-                    if errors.is_empty() {
-                        Ok(())
-                    } else {
-                        Err(Composited::Array(errors))
-                    }
-                }
-            }
-
-            impl<T> $ValidateCompositedTrait for Option<T>
-            where
-                T: $ValidateCompositedTrait,
-            {
-                fn $validate_composited_method(
-                    &self,
-                    $limit: $limit_type,
-                ) -> Result<(), Composited<$Error>> {
-                    match self {
-                        Some(value) => value.$validate_composited_method($limit),
-                        None => Ok(()),
-                    }
+        impl<T> $ValidateCompositedTrait for Option<T>
+        where
+            T: $ValidateCompositedTrait,
+        {
+            fn $validate_composited_method(
+                &self,
+                $limit: $limit_type,
+            ) -> Result<(), Composited<$Error>> {
+                match self {
+                    Some(value) => value.$validate_composited_method($limit),
+                    None => Ok(()),
                 }
             }
         }
@@ -135,6 +134,7 @@ macro_rules! impl_composited_validation_1args {
                 $limit:ident: $limit_type:ty$(,)*
             ) -> Result<(), Composited<$Error:ty>>;
         }
+        via $ValidateTrait:ident::$validate_method:ident;
 
         impl<K, V> $ValidateCompositedTrait2:ident for std::collections::HashMap<K, V>
         where
@@ -147,32 +147,32 @@ macro_rules! impl_composited_validation_1args {
                     $limit: $limit_type
                 ) -> Result<(), Composited<$Error>>;
             }
+            via $ValidateTrait::$validate_method;
         );
-        paste::paste! {
-            impl<K, V> $ValidateCompositedTrait2 for std::collections::HashMap<K, V>
-            where
-                V: $ValidateCompositedTrait3,
-            {
-                fn $validate_composited_method(
-                    &self,
-                    $limit: $limit_type,
-                ) -> Result<(), Composited<$Error>> {
-                    let errors: IndexMap<usize, crate::validation::Composited<$Error>> = self
-                        .iter()
-                        .enumerate()
-                        .filter_map(
-                            |(index, (_key, value))| match value.$validate_composited_method($limit) {
-                                Ok(_) => None,
-                                Err(error) => Some((index, error)),
-                            },
-                        )
-                        .collect();
 
-                    if errors.is_empty() {
-                        Ok(())
-                    } else {
-                        Err(Composited::Array(errors))
-                    }
+        impl<K, V> $ValidateCompositedTrait2 for std::collections::HashMap<K, V>
+        where
+            V: $ValidateCompositedTrait3,
+        {
+            fn $validate_composited_method(
+                &self,
+                $limit: $limit_type,
+            ) -> Result<(), Composited<$Error>> {
+                let errors: IndexMap<usize, crate::validation::Composited<$Error>> = self
+                    .iter()
+                    .enumerate()
+                    .filter_map(
+                        |(index, (_key, value))| match value.$validate_composited_method($limit) {
+                            Ok(_) => None,
+                            Err(error) => Some((index, error)),
+                        },
+                    )
+                    .collect();
+
+                if errors.is_empty() {
+                    Ok(())
+                } else {
+                    Err(Composited::Array(errors))
                 }
             }
         }
@@ -293,21 +293,23 @@ macro_rules! impl_composited_validation_1args {
 
 macro_rules! impl_generic_composited_validation_1args {
     (
-        $ErrorType:ident,
+        $ValidateCompositedTrait:ident,
+        $validate_composited_method:ident,
+        $ValidateTrait:ident,
+        $validate_method:ident,
+        $Error:ident,
         $type:ty
     ) => {
-        paste::paste! {
-            impl<T> [<ValidateComposited $ErrorType >]<$type> for T
-            where
-                T: [<Validate $ErrorType >]<$type>,
-            {
-                fn [< validate_composited_ $ErrorType:snake>](
-                    &self,
-                    limit: $type,
-                ) -> Result<(), crate::validation::Composited<[<$ErrorType Error>]>> {
-                    self.[< validate_ $ErrorType:snake>](limit)
-                        .map_err(|error| crate::validation::Composited::Single(error))
-                }
+        impl<T> $ValidateCompositedTrait<$type> for T
+        where
+            T: $ValidateTrait<$type>,
+        {
+            fn $validate_composited_method(
+                &self,
+                limit: $type,
+            ) -> Result<(), crate::validation::Composited<$Error>> {
+                self.$validate_method(limit)
+                    .map_err(|error| crate::validation::Composited::Single(error))
             }
         }
     };
@@ -363,6 +365,7 @@ impl_composited_validation_1args!(
             max_length: usize,
         ) -> Result<(), Composited<MaxLengthError>>;
     }
+    via ValidateMaxLength::validate_max_length;
 
     impl<K, V> ValidateCompositedMaxLength for std::collections::HashMap<K, V>
     where
@@ -376,6 +379,7 @@ impl_composited_validation_1args!(
             min_length: usize,
         ) -> Result<(), Composited<MinLengthError>>;
     }
+    via ValidateMinLength::validate_min_length;
 
     impl<K, V> ValidateCompositedMinLength for std::collections::HashMap<K, V>
     where
@@ -389,6 +393,7 @@ impl_composited_validation_1args!(
             pattern: &regex::Regex,
         ) -> Result<(), Composited<PatternError>>;
     }
+    via ValidatePattern::validate_pattern;
 
     impl<K, V> ValidateCompositedPattern for std::collections::HashMap<K, V>
     where
@@ -403,6 +408,7 @@ impl_composited_validation_1args!(
             max_properties: usize,
         ) -> Result<(), Composited<MaxPropertiesError>>;
     }
+    via ValidateMaxProperties::validate_max_properties;
 );
 
 impl_composited_validation_1args!(
@@ -412,6 +418,7 @@ impl_composited_validation_1args!(
             min_properties: usize,
         ) -> Result<(), Composited<MinPropertiesError>>;
     }
+    via ValidateMinProperties::validate_min_properties;
 );
 
 // Generic

--- a/crates/serde_valid/src/validation/array.rs
+++ b/crates/serde_valid/src/validation/array.rs
@@ -9,22 +9,20 @@ pub use unique_items::ValidateUniqueItems;
 use crate::{MaxItemsError, MinItemsError};
 
 macro_rules! impl_validate_array_length_items {
-    ($ErrorType:ident) => {
-        paste::paste! {
-            impl<T> [<Validate $ErrorType>] for Option<T>
-            where
-                T: [<Validate $ErrorType>],
-            {
-                fn [<validate_ $ErrorType:snake>] (&self, limit: usize) -> Result<(), [<$ErrorType Error>]> {
-                    match self {
-                        Some(value) => value.[<validate_ $ErrorType:snake>](limit),
-                        None => Ok(()),
-                    }
+    ($ValidateTrait:ident, $validate_method:ident, $Error:ident) => {
+        impl<T> $ValidateTrait for Option<T>
+        where
+            T: $ValidateTrait,
+        {
+            fn $validate_method(&self, limit: usize) -> Result<(), $Error> {
+                match self {
+                    Some(value) => value.$validate_method(limit),
+                    None => Ok(()),
                 }
             }
         }
     };
 }
 
-impl_validate_array_length_items!(MaxItems);
-impl_validate_array_length_items!(MinItems);
+impl_validate_array_length_items!(ValidateMaxItems, validate_max_items, MaxItemsError);
+impl_validate_array_length_items!(ValidateMinItems, validate_min_items, MinItemsError);

--- a/crates/serde_valid/src/validation/composited.rs
+++ b/crates/serde_valid/src/validation/composited.rs
@@ -29,25 +29,32 @@ pub enum Composited<Error> {
 }
 
 macro_rules! impl_into_error {
-    ($ErrorType:ident) => {
-        paste::paste! {
-            impl IntoError<[<$ErrorType Error>]> for Composited<[<$ErrorType Error>]> {
-                fn into_error_by(self, format: crate::validation::error::Format<[<$ErrorType Error>]>) -> crate::validation::error::Error {
-                    match self {
-                        Composited::Single(single) => {
-                            crate::validation::error::Error::$ErrorType(format.into_message(single))
-                        },
-                        Composited::Array(array) =>{
-                            crate::validation::error::Error::Items(crate::validation::error::ArrayErrors::new(
+    ($ErrorType:ident => $Error:ident) => {
+        impl IntoError<$Error> for Composited<$Error> {
+            fn into_error_by(
+                self,
+                format: crate::validation::error::Format<$Error>,
+            ) -> crate::validation::error::Error {
+                match self {
+                    Composited::Single(single) => {
+                        crate::validation::error::Error::$ErrorType(format.into_message(single))
+                    }
+                    Composited::Array(array) => crate::validation::error::Error::Items(
+                        crate::validation::error::ArrayErrors::new(
                             Vec::with_capacity(0),
                             array
                                 .into_iter()
                                 .map(|(index, params)| {
-                                    (index, crate::validation::Errors::NewType(vec![params.into_error_by(format.clone())]))
+                                    (
+                                        index,
+                                        crate::validation::Errors::NewType(vec![
+                                            params.into_error_by(format.clone())
+                                        ]),
+                                    )
                                 })
                                 .collect::<IndexMap<_, _>>(),
-                        ))},
-                    }
+                        ),
+                    ),
                 }
             }
         }
@@ -55,25 +62,25 @@ macro_rules! impl_into_error {
 }
 
 // Global
-impl_into_error!(Enum);
+impl_into_error!(Enum => EnumError);
 
 // Numeric
-impl_into_error!(Maximum);
-impl_into_error!(Minimum);
-impl_into_error!(ExclusiveMaximum);
-impl_into_error!(ExclusiveMinimum);
-impl_into_error!(MultipleOf);
+impl_into_error!(Maximum => MaximumError);
+impl_into_error!(Minimum => MinimumError);
+impl_into_error!(ExclusiveMaximum => ExclusiveMaximumError);
+impl_into_error!(ExclusiveMinimum => ExclusiveMinimumError);
+impl_into_error!(MultipleOf => MultipleOfError);
 
 // String
-impl_into_error!(MaxLength);
-impl_into_error!(MinLength);
-impl_into_error!(Pattern);
+impl_into_error!(MaxLength => MaxLengthError);
+impl_into_error!(MinLength => MinLengthError);
+impl_into_error!(Pattern => PatternError);
 
 // Array
-impl_into_error!(MaxItems);
-impl_into_error!(MinItems);
-impl_into_error!(UniqueItems);
+impl_into_error!(MaxItems => MaxItemsError);
+impl_into_error!(MinItems => MinItemsError);
+impl_into_error!(UniqueItems => UniqueItemsError);
 
 // Object
-impl_into_error!(MaxProperties);
-impl_into_error!(MinProperties);
+impl_into_error!(MaxProperties => MaxPropertiesError);
+impl_into_error!(MinProperties => MinPropertiesError);

--- a/crates/serde_valid/src/validation/numeric/exclusive_maximum.rs
+++ b/crates/serde_valid/src/validation/numeric/exclusive_maximum.rs
@@ -62,7 +62,14 @@ macro_rules! impl_validate_numeric_exclusive_maximum {
             }
         }
 
-        impl_generic_composited_validation_1args!(ExclusiveMaximum, $type);
+        impl_generic_composited_validation_1args!(
+            ValidateCompositedExclusiveMaximum,
+            validate_composited_exclusive_maximum,
+            ValidateExclusiveMaximum,
+            validate_exclusive_maximum,
+            ExclusiveMaximumError,
+            $type
+        );
     };
 }
 

--- a/crates/serde_valid/src/validation/numeric/exclusive_minimum.rs
+++ b/crates/serde_valid/src/validation/numeric/exclusive_minimum.rs
@@ -62,7 +62,14 @@ macro_rules! impl_validate_numeric_exclusive_minimum {
             }
         }
 
-        impl_generic_composited_validation_1args!(ExclusiveMinimum, $type);
+        impl_generic_composited_validation_1args!(
+            ValidateCompositedExclusiveMinimum,
+            validate_composited_exclusive_minimum,
+            ValidateExclusiveMinimum,
+            validate_exclusive_minimum,
+            ExclusiveMinimumError,
+            $type
+        );
     };
 }
 

--- a/crates/serde_valid/src/validation/numeric/maximum.rs
+++ b/crates/serde_valid/src/validation/numeric/maximum.rs
@@ -56,7 +56,14 @@ macro_rules! impl_validate_numeric_maximum {
             }
         }
 
-        impl_generic_composited_validation_1args!(Maximum, $type);
+        impl_generic_composited_validation_1args!(
+            ValidateCompositedMaximum,
+            validate_composited_maximum,
+            ValidateMaximum,
+            validate_maximum,
+            MaximumError,
+            $type
+        );
     };
 }
 

--- a/crates/serde_valid/src/validation/numeric/minimum.rs
+++ b/crates/serde_valid/src/validation/numeric/minimum.rs
@@ -56,7 +56,14 @@ macro_rules! impl_validate_numeric_minimum {
             }
         }
 
-        impl_generic_composited_validation_1args!(Minimum, $type);
+        impl_generic_composited_validation_1args!(
+            ValidateCompositedMinimum,
+            validate_composited_minimum,
+            ValidateMinimum,
+            validate_minimum,
+            MinimumError,
+            $type
+        );
     };
 }
 

--- a/crates/serde_valid/src/validation/numeric/multiple_of.rs
+++ b/crates/serde_valid/src/validation/numeric/multiple_of.rs
@@ -66,7 +66,14 @@ macro_rules! impl_validate_numeric_multiple_of {
             }
         }
 
-        impl_generic_composited_validation_1args!(MultipleOf, $type);
+        impl_generic_composited_validation_1args!(
+            ValidateCompositedMultipleOf,
+            validate_composited_multiple_of,
+            ValidateMultipleOf,
+            validate_multiple_of,
+            MultipleOfError,
+            $type
+        );
     };
 }
 

--- a/crates/serde_valid_derive/Cargo.toml
+++ b/crates/serde_valid_derive/Cargo.toml
@@ -16,7 +16,6 @@ proc-macro = true
 
 [dependencies]
 itertools.workspace = true
-paste.workspace = true
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 strsim = { workspace = true }

--- a/crates/serde_valid_derive/src/attribute/field_validate/array/length_items.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/array/length_items.rs
@@ -10,52 +10,68 @@ use quote::quote;
 ///
 /// See <https://json-schema.org/understanding-json-schema/reference/array.html#length>
 macro_rules! extract_array_length_validator{
-    ($ErrorType:ident) => {
-        paste::paste! {
-            pub fn [<extract_array_ $ErrorType:snake _validator>](
-                field: &impl Field,
-                validation_value: &syn::Lit,
-                message_format: MessageFormat,
-                rename_map: &RenameMap,
-            ) -> Result<Validator, crate::Errors> {
-                [<inner_extract_array_ $ErrorType:snake _validator>](field, validation_value, message_format, rename_map)
-            }
+    (
+        $ErrorType:ident,
+        $extract_validator:ident,
+        $inner_extract_validator:ident,
+        $ValidateTrait:ident,
+        $validate_method:ident
+    ) => {
+        pub fn $extract_validator(
+            field: &impl Field,
+            validation_value: &syn::Lit,
+            message_format: MessageFormat,
+            rename_map: &RenameMap,
+        ) -> Result<Validator, crate::Errors> {
+            $inner_extract_validator(field, validation_value, message_format, rename_map)
+        }
 
-            fn [<inner_extract_array_ $ErrorType:snake _validator>](
-                field: &impl Field,
-                validation_value: &syn::Lit,
-                message_format: MessageFormat,
-                rename_map: &RenameMap,
-            ) -> Result<TokenStream, crate::Errors> {
-                let field_name = field.name();
-                let field_ident = field.ident();
-                let field_key = field.key();
-                let rename = rename_map.get(field_name).unwrap_or(&field_key);
-                let [<$ErrorType:snake>] = get_numeric(validation_value)?;
-                let errors = field.errors_variable();
+        fn $inner_extract_validator(
+            field: &impl Field,
+            validation_value: &syn::Lit,
+            message_format: MessageFormat,
+            rename_map: &RenameMap,
+        ) -> Result<TokenStream, crate::Errors> {
+            let field_name = field.name();
+            let field_ident = field.ident();
+            let field_key = field.key();
+            let rename = rename_map.get(field_name).unwrap_or(&field_key);
+            let limit = get_numeric(validation_value)?;
+            let errors = field.errors_variable();
 
-                Ok(quote!(
-                    if let Err(error_params) = ::serde_valid::[<Validate $ErrorType>]::[<validate_ $ErrorType:snake>](
-                        #field_ident,
-                        #[<$ErrorType:snake>],
-                    ) {
-                        use ::serde_valid::validation::error::FormatDefault;
+            Ok(quote!(
+                if let Err(error_params) = ::serde_valid::$ValidateTrait::$validate_method(
+                    #field_ident,
+                    #limit,
+                ) {
+                    use ::serde_valid::validation::error::FormatDefault;
 
-                        #errors
-                            .entry(#rename)
-                            .or_default()
-                            .push(::serde_valid::validation::Error::$ErrorType(
-                                ::serde_valid::validation::error::Message::new(
-                                    error_params,
-                                    #message_format,
-                                )
-                            ));
-                    }
-                ))
-            }
+                    #errors
+                        .entry(#rename)
+                        .or_default()
+                        .push(::serde_valid::validation::Error::$ErrorType(
+                            ::serde_valid::validation::error::Message::new(
+                                error_params,
+                                #message_format,
+                            )
+                        ));
+                }
+            ))
         }
     }
 }
 
-extract_array_length_validator!(MaxItems);
-extract_array_length_validator!(MinItems);
+extract_array_length_validator!(
+    MaxItems,
+    extract_array_max_items_validator,
+    inner_extract_array_max_items_validator,
+    ValidateMaxItems,
+    validate_max_items
+);
+extract_array_length_validator!(
+    MinItems,
+    extract_array_min_items_validator,
+    inner_extract_array_min_items_validator,
+    ValidateMinItems,
+    validate_min_items
+);

--- a/crates/serde_valid_derive/src/attribute/field_validate/numeric/range.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/numeric/range.rs
@@ -9,49 +9,72 @@ use quote::quote;
 ///
 /// See <https://json-schema.org/understanding-json-schema/reference/numeric.html#range>
 macro_rules! extract_numeric_range_validator{
-    ($ErrorType:ident) => {
-        paste::paste! {
-            pub fn [<extract_numeric_ $ErrorType:snake _validator>](
-                field: &impl Field,
-                validation_value: &syn::Expr,
-                message_format: MessageFormat,
-                rename_map: &RenameMap,
-            ) -> Result<Validator, crate::Errors> {
-                [<inner_extract_numeric_ $ErrorType:snake _validator>](field, validation_value, message_format, rename_map)
-            }
+    (
+        $extract_validator:ident,
+        $inner_extract_validator:ident,
+        $ValidateCompositedTrait:ident,
+        $validate_composited_method:ident
+    ) => {
+        pub fn $extract_validator(
+            field: &impl Field,
+            validation_value: &syn::Expr,
+            message_format: MessageFormat,
+            rename_map: &RenameMap,
+        ) -> Result<Validator, crate::Errors> {
+            $inner_extract_validator(field, validation_value, message_format, rename_map)
+        }
 
-            fn [<inner_extract_numeric_ $ErrorType:snake _validator>](
-                field: &impl Field,
-                validation_value: &syn::Expr,
-                message_format: MessageFormat,
-                rename_map: &RenameMap,
-            ) -> Result<TokenStream, crate::Errors> {
-                let field_name = field.name();
-                let field_ident = field.ident();
-                let field_key = field.key();
-                let rename = rename_map.get(field_name).unwrap_or(&field_key);
-                let errors = field.errors_variable();
+        fn $inner_extract_validator(
+            field: &impl Field,
+            validation_value: &syn::Expr,
+            message_format: MessageFormat,
+            rename_map: &RenameMap,
+        ) -> Result<TokenStream, crate::Errors> {
+            let field_name = field.name();
+            let field_ident = field.ident();
+            let field_key = field.key();
+            let rename = rename_map.get(field_name).unwrap_or(&field_key);
+            let errors = field.errors_variable();
 
-                Ok(quote!(
-                    if let Err(__composited_error_params) = ::serde_valid::validation::[<ValidateComposited $ErrorType>]::[<validate_composited_ $ErrorType:snake>](
-                        #field_ident,
-                        #validation_value,
-                    ) {
-                        use ::serde_valid::validation::IntoError;
-                        use ::serde_valid::validation::error::FormatDefault;
+            Ok(quote!(
+                if let Err(__composited_error_params) = ::serde_valid::validation::$ValidateCompositedTrait::$validate_composited_method(
+                    #field_ident,
+                    #validation_value,
+                ) {
+                    use ::serde_valid::validation::IntoError;
+                    use ::serde_valid::validation::error::FormatDefault;
 
-                        #errors
-                            .entry(#rename)
-                            .or_default()
-                            .push(__composited_error_params.into_error_by(#message_format));
-                    }
-                ))
-            }
+                    #errors
+                        .entry(#rename)
+                        .or_default()
+                        .push(__composited_error_params.into_error_by(#message_format));
+                }
+            ))
         }
     }
 }
 
-extract_numeric_range_validator!(Maximum);
-extract_numeric_range_validator!(Minimum);
-extract_numeric_range_validator!(ExclusiveMaximum);
-extract_numeric_range_validator!(ExclusiveMinimum);
+extract_numeric_range_validator!(
+    extract_numeric_maximum_validator,
+    inner_extract_numeric_maximum_validator,
+    ValidateCompositedMaximum,
+    validate_composited_maximum
+);
+extract_numeric_range_validator!(
+    extract_numeric_minimum_validator,
+    inner_extract_numeric_minimum_validator,
+    ValidateCompositedMinimum,
+    validate_composited_minimum
+);
+extract_numeric_range_validator!(
+    extract_numeric_exclusive_maximum_validator,
+    inner_extract_numeric_exclusive_maximum_validator,
+    ValidateCompositedExclusiveMaximum,
+    validate_composited_exclusive_maximum
+);
+extract_numeric_range_validator!(
+    extract_numeric_exclusive_minimum_validator,
+    inner_extract_numeric_exclusive_minimum_validator,
+    ValidateCompositedExclusiveMinimum,
+    validate_composited_exclusive_minimum
+);

--- a/crates/serde_valid_derive/src/attribute/field_validate/object/size_properties.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/object/size_properties.rs
@@ -10,48 +10,61 @@ use quote::quote;
 ///
 /// See <https://json-schema.org/understanding-json-schema/reference/object.html#size>
 macro_rules! extract_object_size_validator {
-    ($ErrorType:ident) => {
-        paste::paste! {
-            pub fn [<extract_object_ $ErrorType:snake _validator>](
-                field: &impl Field,
-                validation_value: &syn::Lit,
-                message_format: MessageFormat,
-                rename_map: &RenameMap,
-            ) -> Result<Validator, crate::Errors> {
-                [<inner_extract_object_ $ErrorType:snake _validator>](field, validation_value, message_format, rename_map)
-            }
+    (
+        $extract_validator:ident,
+        $inner_extract_validator:ident,
+        $ValidateCompositedTrait:ident,
+        $validate_composited_method:ident
+    ) => {
+        pub fn $extract_validator(
+            field: &impl Field,
+            validation_value: &syn::Lit,
+            message_format: MessageFormat,
+            rename_map: &RenameMap,
+        ) -> Result<Validator, crate::Errors> {
+            $inner_extract_validator(field, validation_value, message_format, rename_map)
+        }
 
-            fn [<inner_extract_object_ $ErrorType:snake _validator>](
-                field: &impl Field,
-                validation_value: &syn::Lit,
-                message_format: MessageFormat,
-                rename_map: &RenameMap,
-            ) -> Result<TokenStream, crate::Errors> {
-                let field_name = field.name();
-                let field_ident = field.ident();
-                let field_key = field.key();
-                let rename = rename_map.get(field_name).unwrap_or(&field_key);
-                let errors = field.errors_variable();
-                let [<$ErrorType:snake>] = get_numeric(validation_value)?;
+        fn $inner_extract_validator(
+            field: &impl Field,
+            validation_value: &syn::Lit,
+            message_format: MessageFormat,
+            rename_map: &RenameMap,
+        ) -> Result<TokenStream, crate::Errors> {
+            let field_name = field.name();
+            let field_ident = field.ident();
+            let field_key = field.key();
+            let rename = rename_map.get(field_name).unwrap_or(&field_key);
+            let errors = field.errors_variable();
+            let limit = get_numeric(validation_value)?;
 
-                Ok(quote!(
-                    if let Err(__composited_error_params) = ::serde_valid::validation::[<ValidateComposited $ErrorType>]::[<validate_composited_ $ErrorType:snake>](
-                        #field_ident,
-                        #[<$ErrorType:snake>]
-                    ) {
-                        use ::serde_valid::validation::IntoError;
-                        use ::serde_valid::validation::error::FormatDefault;
+            Ok(quote!(
+                if let Err(__composited_error_params) = ::serde_valid::validation::$ValidateCompositedTrait::$validate_composited_method(
+                    #field_ident,
+                    #limit
+                ) {
+                    use ::serde_valid::validation::IntoError;
+                    use ::serde_valid::validation::error::FormatDefault;
 
-                        #errors
-                            .entry(#rename)
-                            .or_default()
-                            .push(__composited_error_params.into_error_by(#message_format));
-                    }
-                ))
-            }
+                    #errors
+                        .entry(#rename)
+                        .or_default()
+                        .push(__composited_error_params.into_error_by(#message_format));
+                }
+            ))
         }
     }
 }
 
-extract_object_size_validator!(MaxProperties);
-extract_object_size_validator!(MinProperties);
+extract_object_size_validator!(
+    extract_object_max_properties_validator,
+    inner_extract_object_max_properties_validator,
+    ValidateCompositedMaxProperties,
+    validate_composited_max_properties
+);
+extract_object_size_validator!(
+    extract_object_min_properties_validator,
+    inner_extract_object_min_properties_validator,
+    ValidateCompositedMinProperties,
+    validate_composited_min_properties
+);

--- a/crates/serde_valid_derive/src/attribute/field_validate/string/length.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/string/length.rs
@@ -10,48 +10,61 @@ use quote::quote;
 ///
 /// See <https://json-schema.org/understanding-json-schema/reference/string.html#length>
 macro_rules! extract_string_length_validator{
-    ($ErrorType:ident) => {
-        paste::paste! {
-            pub fn [<extract_string_ $ErrorType:snake _validator>](
-                field: &impl Field,
-                validation_value: &syn::Lit,
-                message_format: MessageFormat,
-                rename_map: &RenameMap,
-            ) -> Result<Validator, crate::Errors> {
-                [<inner_extract_string_ $ErrorType:snake _validator>](field, validation_value, message_format, rename_map)
-            }
+    (
+        $extract_validator:ident,
+        $inner_extract_validator:ident,
+        $ValidateCompositedTrait:ident,
+        $validate_composited_method:ident
+    ) => {
+        pub fn $extract_validator(
+            field: &impl Field,
+            validation_value: &syn::Lit,
+            message_format: MessageFormat,
+            rename_map: &RenameMap,
+        ) -> Result<Validator, crate::Errors> {
+            $inner_extract_validator(field, validation_value, message_format, rename_map)
+        }
 
-            fn [<inner_extract_string_ $ErrorType:snake _validator>](
-                field: &impl Field,
-                validation_value: &syn::Lit,
-                message_format: MessageFormat,
-                rename_map: &RenameMap,
-            ) -> Result<TokenStream, crate::Errors> {
-                let field_name = field.name();
-                let field_ident = field.ident();
-                let field_key = field.key();
-                let rename = rename_map.get(field_name).unwrap_or(&field_key);
-                let errors = field.errors_variable();
-                let [<$ErrorType:snake>] = get_numeric(validation_value)?;
+        fn $inner_extract_validator(
+            field: &impl Field,
+            validation_value: &syn::Lit,
+            message_format: MessageFormat,
+            rename_map: &RenameMap,
+        ) -> Result<TokenStream, crate::Errors> {
+            let field_name = field.name();
+            let field_ident = field.ident();
+            let field_key = field.key();
+            let rename = rename_map.get(field_name).unwrap_or(&field_key);
+            let errors = field.errors_variable();
+            let limit = get_numeric(validation_value)?;
 
-                Ok(quote!(
-                    if let Err(__composited_error_params) = ::serde_valid::validation::[<ValidateComposited $ErrorType>]::[<validate_composited_ $ErrorType:snake>](
-                        #field_ident,
-                        #[<$ErrorType:snake>],
-                    ) {
-                        use ::serde_valid::validation::IntoError;
-                        use ::serde_valid::validation::error::FormatDefault;
+            Ok(quote!(
+                if let Err(__composited_error_params) = ::serde_valid::validation::$ValidateCompositedTrait::$validate_composited_method(
+                    #field_ident,
+                    #limit,
+                ) {
+                    use ::serde_valid::validation::IntoError;
+                    use ::serde_valid::validation::error::FormatDefault;
 
-                        #errors
-                            .entry(#rename)
-                            .or_default()
-                            .push(__composited_error_params.into_error_by(#message_format));
-                    }
-                ))
-            }
+                    #errors
+                        .entry(#rename)
+                        .or_default()
+                        .push(__composited_error_params.into_error_by(#message_format));
+                }
+            ))
         }
     }
 }
 
-extract_string_length_validator!(MaxLength);
-extract_string_length_validator!(MinLength);
+extract_string_length_validator!(
+    extract_string_max_length_validator,
+    inner_extract_string_max_length_validator,
+    ValidateCompositedMaxLength,
+    validate_composited_max_length
+);
+extract_string_length_validator!(
+    extract_string_min_length_validator,
+    inner_extract_string_min_length_validator,
+    ValidateCompositedMinLength,
+    validate_composited_min_length
+);

--- a/crates/serde_valid_literal/Cargo.toml
+++ b/crates/serde_valid_literal/Cargo.toml
@@ -12,7 +12,6 @@ categories = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-paste = { workspace = true }
 regex = { workspace = true }
 
 [features]

--- a/crates/serde_valid_literal/src/number.rs
+++ b/crates/serde_valid_literal/src/number.rs
@@ -77,50 +77,48 @@ impl std::fmt::Display for Number {
 }
 
 macro_rules! impl_from_trait {
-    ($type:ty) => {
-        paste::paste! {
-            impl From<$type> for Number {
-                fn from(item: $type) -> Self {
-                    Number::[<$type:camel>](item)
-                }
+    ($type:ty => $variant:ident) => {
+        impl From<$type> for Number {
+            fn from(item: $type) -> Self {
+                Number::$variant(item)
             }
+        }
 
-            impl From<&$type> for Number {
-                fn from(item: &$type) -> Self {
-                    Number::[<$type:camel>](*item)
-                }
+        impl From<&$type> for Number {
+            fn from(item: &$type) -> Self {
+                Number::$variant(*item)
             }
         }
     };
 }
 
-impl_from_trait!(i8);
-impl_from_trait!(i16);
-impl_from_trait!(i32);
-impl_from_trait!(i64);
+impl_from_trait!(i8 => I8);
+impl_from_trait!(i16 => I16);
+impl_from_trait!(i32 => I32);
+impl_from_trait!(i64 => I64);
 #[cfg(feature = "i128")]
-impl_from_trait!(i128);
-impl_from_trait!(isize);
-impl_from_trait!(u8);
-impl_from_trait!(u16);
-impl_from_trait!(u32);
-impl_from_trait!(u64);
+impl_from_trait!(i128 => I128);
+impl_from_trait!(isize => Isize);
+impl_from_trait!(u8 => U8);
+impl_from_trait!(u16 => U16);
+impl_from_trait!(u32 => U32);
+impl_from_trait!(u64 => U64);
 #[cfg(feature = "i128")]
-impl_from_trait!(u128);
-impl_from_trait!(usize);
-impl_from_trait!(NonZeroI8);
-impl_from_trait!(NonZeroI16);
-impl_from_trait!(NonZeroI32);
-impl_from_trait!(NonZeroI64);
+impl_from_trait!(u128 => U128);
+impl_from_trait!(usize => Usize);
+impl_from_trait!(NonZeroI8 => NonZeroI8);
+impl_from_trait!(NonZeroI16 => NonZeroI16);
+impl_from_trait!(NonZeroI32 => NonZeroI32);
+impl_from_trait!(NonZeroI64 => NonZeroI64);
 #[cfg(feature = "i128")]
-impl_from_trait!(NonZeroI128);
-impl_from_trait!(NonZeroIsize);
-impl_from_trait!(NonZeroU8);
-impl_from_trait!(NonZeroU16);
-impl_from_trait!(NonZeroU32);
-impl_from_trait!(NonZeroU64);
+impl_from_trait!(NonZeroI128 => NonZeroI128);
+impl_from_trait!(NonZeroIsize => NonZeroIsize);
+impl_from_trait!(NonZeroU8 => NonZeroU8);
+impl_from_trait!(NonZeroU16 => NonZeroU16);
+impl_from_trait!(NonZeroU32 => NonZeroU32);
+impl_from_trait!(NonZeroU64 => NonZeroU64);
 #[cfg(feature = "i128")]
-impl_from_trait!(NonZeroU128);
-impl_from_trait!(NonZeroUsize);
-impl_from_trait!(f32);
-impl_from_trait!(f64);
+impl_from_trait!(NonZeroU128 => NonZeroU128);
+impl_from_trait!(NonZeroUsize => NonZeroUsize);
+impl_from_trait!(f32 => F32);
+impl_from_trait!(f64 => F64);


### PR DESCRIPTION
## Summary

Removes the dependency on `paste` (unmaintained, RUSTSEC-2024-0436) without migrating to a fork or adding any new dependency. Instead of replacing `paste` with an equivalent, this change eliminates the need for identifier concatenation itself.

- Every `macro_rules!` that used `paste::paste!` to derive identifiers (`extract_numeric_maximum_validator`, `ValidateCompositedMaxLength`, `Number::I8`, etc.) now receives the pre-concatenated identifiers explicitly from the invocation site
  - `serde_valid_literal`: `impl_from_trait!(i8 => I8)` (26 invocations)
  - `serde_valid_derive`: validator-extraction macros take the generated fn / trait / method names as arguments (4 macros)
  - `serde_valid`: `impl_composited_validation_1args!` gains a `via ValidateMaxLength::validate_max_length;` clause; `impl_generic_composited_validation_1args!`, `impl_into_error!`, and `impl_validate_array_length_items!` take explicit idents
- All generated identifiers are byte-for-byte identical to before, so there is no public API change
- As a side effect, previously un-greppable generated identifiers now appear verbatim in the source, improving searchability

This follows the same policy as #113: with several crates in the ecosystem being abandoned, this project prefers removing small dependencies over migrating to successor forks.

Closes #95

## Validation

- `cargo build --workspace --all-features` — passes
- `cargo test --workspace --all-features` — all 32 test suites pass (including doc-tests, which exercise the derive macros)
- `cargo fmt -- --check` / `cargo clippy --workspace --all-features` — zero warnings
- `cargo tree -i paste` — package no longer exists in the dependency graph
- `cargo deny check advisories` — `advisories ok` (the exact command from the issue report; RUSTSEC-2024-0436 resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)