### PR TITLE
refactor: remove unused FormatDefault import from generated code

### DIFF
--- a/crates/serde_valid_derive/src/attribute/field_validate/array/length_items.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/array/length_items.rs
@@ -44,8 +44,6 @@ macro_rules! extract_array_length_validator{
                     #field_ident,
                     #limit,
                 ) {
-                    use ::serde_valid::validation::error::FormatDefault;
-
                     #errors
                         .entry(#rename)
                         .or_default()

--- a/crates/serde_valid_derive/src/attribute/field_validate/array/unique_items.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/array/unique_items.rs
@@ -28,8 +28,6 @@ fn inner_extract_array_unique_items_validator(
         if let Err(error_params) = ::serde_valid::ValidateUniqueItems::validate_unique_items(
             #field_ident
         ) {
-            use ::serde_valid::validation::error::FormatDefault;
-
             #errors
                 .entry(#rename)
                 .or_default()

--- a/crates/serde_valid_derive/src/attribute/field_validate/generic/enum.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/generic/enum.rs
@@ -34,7 +34,6 @@ fn inner_extract_generic_enum_validator(
             &[#lits],
         ) {
             use ::serde_valid::validation::IntoError;
-            use ::serde_valid::validation::error::FormatDefault;
 
             #errors
                 .entry(#rename)

--- a/crates/serde_valid_derive/src/attribute/field_validate/numeric/multiple_of.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/numeric/multiple_of.rs
@@ -34,7 +34,6 @@ fn inner_extract_numeric_multiple_of_validator(
             #multiple_of,
         ) {
             use ::serde_valid::validation::IntoError;
-            use ::serde_valid::validation::error::FormatDefault;
 
             #errors
                 .entry(#rename)

--- a/crates/serde_valid_derive/src/attribute/field_validate/numeric/range.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/numeric/range.rs
@@ -42,7 +42,6 @@ macro_rules! extract_numeric_range_validator{
                     #validation_value,
                 ) {
                     use ::serde_valid::validation::IntoError;
-                    use ::serde_valid::validation::error::FormatDefault;
 
                     #errors
                         .entry(#rename)

--- a/crates/serde_valid_derive/src/attribute/field_validate/object/size_properties.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/object/size_properties.rs
@@ -44,7 +44,6 @@ macro_rules! extract_object_size_validator {
                     #limit
                 ) {
                     use ::serde_valid::validation::IntoError;
-                    use ::serde_valid::validation::error::FormatDefault;
 
                     #errors
                         .entry(#rename)

--- a/crates/serde_valid_derive/src/attribute/field_validate/string/length.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/string/length.rs
@@ -44,7 +44,6 @@ macro_rules! extract_string_length_validator{
                     #limit,
                 ) {
                     use ::serde_valid::validation::IntoError;
-                    use ::serde_valid::validation::error::FormatDefault;
 
                     #errors
                         .entry(#rename)

--- a/crates/serde_valid_derive/src/attribute/field_validate/string/pattern.rs
+++ b/crates/serde_valid_derive/src/attribute/field_validate/string/pattern.rs
@@ -40,7 +40,6 @@ fn inner_extract_string_pattern_validator(
             __pattern,
         ) {
             use ::serde_valid::validation::IntoError;
-            use ::serde_valid::validation::error::FormatDefault;
 
             #errors
                 .entry(#rename)


### PR DESCRIPTION
## Summary

Follow-up to the Copilot review findings on #114.

The code generated by the derive macros included `use ::serde_valid::validation::error::FormatDefault;`, but the generated tokens never call any method of that trait — the only trait method invoked is `IntoError::into_error_by`, and `Message::new` is an inherent function. The import was dead output, so this PR removes it from all eight `quote!` blocks in `serde_valid_derive` (the four files touched by #114 plus `pattern.rs`, `enum.rs`, `multiple_of.rs`, and `unique_items.rs`, which had the same vestigial import).

Note that the import caused no actual downstream warnings (rustc suppresses `unused_imports` for proc-macro-expanded code, verified with a `#![deny(unused_imports)]` test crate), so this is purely a cleanup that slightly reduces the generated token output. No behavior or public API change.

## Validation

- `cargo build --workspace --all-features` — passes
- `cargo test --workspace --all-features` — all 32 test suites pass (doc-tests exercise every validator's generated code)
- `cargo fmt -- --check` / `cargo clippy --workspace --all-features` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)