### PR TITLE
chore: bump version to 2.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "xtask"]
 
 [workspace.package]
-version = "2.0.1"
+version = "2.0.2"
 # tombi: lint.rules.deprecated.disabled = true
 authors = ["ya7010 <ya7010@outlook.com>"]
 edition = "2021"
@@ -18,7 +18,7 @@ quote = "^1.0"
 regex = "^1.12"
 serde = "^1.0"
 serde_json = "^1.0"
-serde_valid_derive = { path = "crates/serde_valid_derive" }
-serde_valid_literal = { path = "crates/serde_valid_literal" }
+serde_valid_derive = { path = "crates/serde_valid_derive" , version = "2.0.2"}
+serde_valid_literal = { path = "crates/serde_valid_literal" , version = "2.0.2"}
 strsim = "^0.11"
 syn = { version = "^2.0", features = ["extra-traits", "full"] }


### PR DESCRIPTION
## Summary
- bump workspace package version to 2.0.2
- add publish-time version constraints for internal crates via xtask update-tags

## Verification
- cargo test --all-features
- cargo package -p serde_valid_derive --allow-dirty
- cargo package -p serde_valid_literal --allow-dirty

Note: cargo package for serde_valid requires serde_valid_derive 2.0.2 to exist on crates.io first, matching the publish workflow order.